### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ The expression pattern of two genes in one gene dysregulaiton could be visulazie
 ```{r, eval = FALSE}
 plotDysregExp(tf = dysreg.res$TF[1], tar = dysreg.res$Target[1],
               exp.1 = exp.1,exp.2 = exp.2, 
-              exp1.lab = 'Response',exp2.lab = 'No-response',
-              dysreg = dysreg.res, method ='dysreg', conf.int.level = 0.95)
+              	exp1.label = 'Response', exp2.label = 'No-response',
+              dysreg = dysreg.res, method ='DysReg', conf.int.level = 0.95)
 ```
 
 ## Usage


### PR DESCRIPTION
On July 13th, 2021, we fix the bug in quick start and vignette with the help of Wei Wu. This bug make errors in plotDysregExp() because inputting the error format data into plot.window(). 
########################################## quick start################
plotDysregExp(tf = dysreg.res$TF[1], tar = dysreg.res$Target[1],
              exp.1 = exp.1,exp.2 = exp.2, 
              exp1.lab = 'Response',exp2.lab = 'No-response',
              dysreg = dysreg.res, method ='dysreg', conf.int.level = 0.95)
##################################### vignette#############
plotDysregExp(tf=dysreg.res$TF[1], tar = dysreg.res$Target[1],
	exp.1 = exp.1, exp.2 = exp.2, 
	exp1.label = 'Response', exp2.label = 'No-response',
	dysreg = dysreg.res, method ='DysReg', 
	conf.int.level = 0.95)